### PR TITLE
Add history sort

### DIFF
--- a/app/scripts.babel/popup.js
+++ b/app/scripts.babel/popup.js
@@ -24,6 +24,7 @@ document.addEventListener('DOMContentLoaded', (e) => {
     for (const [i, repo] of full_names.entries()) {
       appendLink(i, repo, ul)
     }
+
     addEventForClick()
   })
 
@@ -183,12 +184,38 @@ const addEventForClick = () => {
       console.log(this.dataset.repo);
       const full_name = this.dataset.repo
 
+      // よくクリックされるリポジトリを上位表示するためクリック数を保存
+      saveClickedReposHistory(full_name)
+
       // NOTE: 新しいタブが開く
-      chrome.tabs.create({ url: 'https://github.com/' + full_name + '/'})
+      //chrome.tabs.create({ url: 'https://github.com/' + full_name + '/'})
     });
   });
 }
 
+const saveClickedReposHistory = (repo) => {
+  const key_name = repo + '::JumpedCnt'
+  const clicked_count = getClickedCnt(key_name)
+
+  clicked_count.then((cnt) => {
+    let obj = {}
+    if(cnt === 'undefined') {
+      obj[key_name] = 1
+      chrome.storage.sync.set(obj)
+    } else {
+      obj[key_name] = cnt + 1
+      chrome.storage.sync.set(obj)
+    }
+  })
+}
+
+const getClickedCnt = (key_name) => {
+  return new Promise((resolve, reject) => {
+    chrome.storage.sync.get(key_name, (v) => {
+      key_name ? resolve(v[key_name]) : reject(v);
+    })
+  })
+}
 
 const setSearchInput = (token) => {
   if ((typeof token === 'undefined') ||

--- a/app/scripts.babel/popup.js
+++ b/app/scripts.babel/popup.js
@@ -226,25 +226,17 @@ const addEventForClick = () => {
 
 const saveClickedReposHistory = (repo) => {
   const key_name = repo + '::JumpedCnt'
-  const clicked_count = getClickedCnt(key_name)
 
-  clicked_count.then((cnt) => {
+  getClickedCnt(key_name).then((cnt) => {
     let obj = {}
-    if(cnt === 'undefined') {
-      obj[key_name] = 1
-      chrome.storage.sync.set(obj)
-    } else {
-      obj[key_name] = cnt + 1
-      chrome.storage.sync.set(obj)
-    }
+    obj[key_name] = cnt === undefined ? 1 : cnt + 1
+    chrome.storage.sync.set(obj)
   })
 }
 
 const getClickedCnt = (key_name) => {
   return new Promise((resolve, reject) => {
-    chrome.storage.sync.get(key_name, (v) => {
-      key_name ? resolve(v[key_name]) : reject(v);
-    })
+    chrome.storage.sync.get(null, (v) => { resolve(v[key_name]) })
   })
 }
 


### PR DESCRIPTION
https://github.com/mochizukikotaro/octojump/issues/11

# what I did
- add the feature that save clicked count and sort by it.

# others
- use chrome storage
  - key: `{repo_name}::JumpedCnt`
  - val: count