### PR TITLE
don't distinguish between uppercase and lowercase

### DIFF
--- a/app/scripts.babel/popup.js
+++ b/app/scripts.babel/popup.js
@@ -144,7 +144,7 @@ const searchRepositories = (word) => {
   var buf = word.replace(/\//, '.*\/.*')
                 .replace(/\s/, '.*')
                 .replace(/(.*)/, '.*$1.*')
-  var reg = new RegExp(buf);
+  var reg = new RegExp(buf, 'i');
 
   findClickedRepos().then((repos) => {
     repos.sort((a,b) => {


### PR DESCRIPTION
https://github.com/mochizukikotaro/octojump/issues/18

hi, @mochizukikotaro.
I add `i` flag to `Regexp` constructor when search repositories😃

https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/RegExp